### PR TITLE
Add support for Python Tools for Visual Studio debugger stream wrapper o...

### DIFF
--- a/win_unicode_console/streams.py
+++ b/win_unicode_console/streams.py
@@ -211,6 +211,10 @@ def check_stream(stream, fileno):
 	if stream is None:	# e.g. with IDLE
 		return True
 	
+	# For Visual Studio Python debugger _DebuggerOutput wrapper
+	if not hasattr(stream, 'fileno') and hasattr(stream, 'old_out'):
+		stream = stream.old_out
+
 	try:
 		_fileno = stream.fileno()
 	except io.UnsupportedOperation:


### PR DESCRIPTION
When Python is running in Visual Studio 2013 with "Python Tools for Visual Studio 2.1" installed then VS debugger wraps stdout and stderr objects inside visualstudio_py_debugger._DebuggerOutput wrappers that tee the output to the IDE Output window. This object does not have fileno method, but we can access it inside original old_out object.

I am not sure whether win-unicode-console should know that it is running in non standard environment (with debugger turned on) or Python Tools for VS should better wrap IO streams and expose fileno() method. I just wanted to make author aware about potential compatibility problem in case this module is chosen as basis for Python 3.5 in scope of http://bugs.python.org/issue1602.
With this patch I can use win-unicode-console both in standalone mode and also from VS debugger.