### PR TITLE
Don't enable readline hook when stdin shouldn't be fixed. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# PyCharm
+.idea/

--- a/win_unicode_console/__init__.py
+++ b/win_unicode_console/__init__.py
@@ -27,7 +27,7 @@ def enable(
 	
 	streams.enable(stdin=stdin, stdout=stdout, stderr=stderr)
 	
-	if use_readline_hook:
+	if use_readline_hook and streams.STDIN.should_be_fixed():
 		readline_hook.enable(use_pyreadline=use_pyreadline)
 	
 	if PY2 and use_raw_input:

--- a/win_unicode_console/readline_hook.py
+++ b/win_unicode_console/readline_hook.py
@@ -131,7 +131,7 @@ if pyreadline:
 
 # PY3 # def enable(*, use_pyreadline=True):
 def enable(use_pyreadline=True):
-	check_encodings()
+	# check_encodings()
 	
 	if use_pyreadline and pyreadline:
 		pyreadline_manager.set_codepage(sys.stdin.encoding)


### PR DESCRIPTION
Changes as suggested in #36, now hopefully in the correct branch.